### PR TITLE
HTML5 input placeholder now works in IE.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,15 +24,6 @@
 //= require jquery.rest
 //= require rails.validations
 //= require jquery-star-rating
+//= require common
 //= require externals/modernizr
 //= require externals/html5support/jquery.html5support
-
-$.ajaxSetup({
-    beforeSend: function(xhr) {
-        xhr.setRequestHeader("Accept", "text/javascript");
-    }
-});
-
-function log(text) {
-  if(window && window.console) console.log(text);
-}

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -1,0 +1,15 @@
+(function($, undefined){
+	$.ajaxSetup({
+	    beforeSend: function(xhr) {
+	        xhr.setRequestHeader("Accept", "text/javascript");
+	    }
+	});
+
+	function log(text) {
+	  if(window && window.console) console.log(text);
+	}
+
+	$(function() {
+		$("input[placeholder]").placeholder();
+	});
+}(jQuery));

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -5,7 +5,7 @@
       .span8
         #searchBox
           = form_for @search, :url => searches_path, :method => 'get', :focus => 'submit', :html => {:id => :search} do |f|
-            = f.search_field :address, :id => 'searchQuery', :placeholder => "Enter an Address", :autofocus => true
+            = f.search_field :address, :id => 'searchQuery', :placeholder => "Enter an Address"
             = f.submit "Search", :id => 'submit', :style => 'text-indent: -9999999px;', :border => '0'
           = link_to 'Advanced Search', searches_path
 


### PR DESCRIPTION
Disable input autofocus as it hides the placeholder in Firefox and IE.
