### PR TITLE
Admin pages now use app theme

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ApplicationController < ApplicationController
-  layout 'admin'
+  layout 'application'
   helper_method :current_user_session, :current_user
   before_filter :require_user
   


### PR DESCRIPTION
This is an important change as right now we're hiding the "Create Day Home" button in the admin pages because of styling conflict.
